### PR TITLE
Add underscore as dependency to the module.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,5 +3,6 @@
   "version": "1.0.1",
   "main": "./angular-underscore-module.js",
   "dependencies": {
+    "underscore": "~1.7.0"
   }
 }


### PR DESCRIPTION
I think it's better to add underscore as dependency to the module, that way installing angular-underscore-module will install the underscore library also.
